### PR TITLE
Improve coach plan builder for large exercise libraries

### DIFF
--- a/Demo_HTML/index.html
+++ b/Demo_HTML/index.html
@@ -1,108 +1,1141 @@
 <!DOCTYPE html>
-<html>
-<body>
-    <h1>Learning JavaScript</h1>
-    <button onclick="showInfo()" style="background-color: yellow; margin: 5px; padding: 10px;">Show Person Info</button>
-    <button onclick="showHobbies()" style="background-color: yellow; margin: 5px; padding: 10px;">Show Hobbies</button>
-    <button onclick="getWeather()" style="background-color: yellow; margin: 5px; padding: 10px;">Get Weather</button>
-    <button onclick="showTime()" style="background-color: yellow; margin: 5px; padding: 10px;">Show Current Time</button>
-    <button onclick="calculateAge()" style="background-color: yellow; margin: 5px; padding: 10px;">Calculate Age</button>
-    <button onclick="showRandomNumber()" style="background-color: yellow; margin: 5px; padding: 10px;">Random Number</button>
-    <button onclick="showLocation()" style="background-color: yellow; margin: 5px; padding: 10px;">Show Location</button>
-    <button onclick="showGreeting()" style="background-color: yellow; margin: 5px; padding: 10px;">Personal Greeting</button>
-    
-    <div id="weatherInfo" style="margin-top: 20px; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9;"></div>
-    
-    <script>
-        // 1. VARIABLES - storing different types of data
-        let name = "John";           // String (text)
-        let age = 20;               // Number
-        let isStudent = true;       // Boolean (true/false)
-        let hobbies = ["reading", "writing", "coding"];  // Array (list)
-        
-        // 2. OBJECT - storing related data together
-        let person = {
-            street: "123 Main St",
-            city: "Anytown"
-        };
-        
-        // 3. FUNCTIONS - reusable blocks of code
-        function showInfo() {
-            alert("Name: " + name + "\nAge: " + age + "\nStudent: " + isStudent);
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Coach Plan Assignment</title>
+    <style>
+        :root {
+            font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+            color: #0f172a;
+            background: #f1f5f9;
         }
-        
-        function showHobbies() {
-            alert("Hobbies: " + hobbies.join(", "));
+
+        * {
+            box-sizing: border-box;
         }
-        
-        function showTime() {
-            const now = new Date();
-            alert("Current time: " + now.toLocaleTimeString());
+
+        body {
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at top left, #f8fafc 0%, #e2e8f0 45%, #cbd5f5 100%);
         }
-        
-        function calculateAge() {
-            const birthYear = 2004;
-            const currentYear = new Date().getFullYear();
-            const calculatedAge = currentYear - birthYear;
-            alert("Age calculation: " + calculatedAge + " years old");
+
+        header {
+            background: #0f172a;
+            color: white;
+            padding: 2.5rem 1.5rem 2rem;
+            text-align: center;
+            box-shadow: 0 24px 40px rgba(15, 23, 42, 0.25);
+            position: relative;
+            overflow: hidden;
         }
-        
-        function showRandomNumber() {
-            const randomNum = Math.floor(Math.random() * 100) + 1;
-            alert("Random number: " + randomNum);
+
+        header::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.25), transparent 55%),
+                        radial-gradient(circle at bottom left, rgba(16, 185, 129, 0.25), transparent 45%);
+            pointer-events: none;
         }
-        
-        function showLocation() {
-            alert("Location: " + person.city + ", " + person.street);
+
+        header h1 {
+            margin: 0;
+            font-size: 2.25rem;
+            font-weight: 700;
         }
-        
-        function showGreeting() {
-            const greeting = "Hello " + name + "! Welcome to JavaScript learning!";
-            alert(greeting);
+
+        header p {
+            margin: 0.75rem auto 0;
+            max-width: 740px;
+            opacity: 0.85;
+            font-size: 1.05rem;
         }
-        
-        // 4. CONSOLE FUNCTION - for testing in browser console
-        function testFunction() {
-            console.log("Hello from console!");
-            console.log("Name:", name);
-            console.log("Age:", age);
-            console.log("All hobbies:", hobbies);
-            console.log("Person object:", person);
+
+        main {
+            max-width: 1240px;
+            margin: 0 auto;
+            padding: 2rem 1.5rem 4rem;
         }
-        
-        // 5. WEATHER API FUNCTION - fetching data from internet
-        async function getWeather() {
-            try {
-                // Show loading message
-                document.getElementById('weatherInfo').innerHTML = "Loading weather data...";
-                
-                // Free weather API (no key required)
-                const response = await fetch('https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.0060&current=temperature_2m');
-                const data = await response.json();
-                
-                // Get temperature from API response
-                const temperature = data.current.temperature_2m;
-                const unit = data.current_units.temperature_2m;
-                
-                // Display weather on page
-                document.getElementById('weatherInfo').innerHTML = 
-                    `<h3>Current Weather</h3>
-                     <p><strong>Temperature:</strong> ${temperature}${unit}</p>
-                     <p><strong>Location:</strong> New York City</p>`;
-                
-                // Also log to console
-                console.log("Weather data:", data);
-                console.log("Temperature:", temperature + unit);
-                
-            } catch (error) {
-                console.error("Error fetching weather:", error);
-                document.getElementById('weatherInfo').innerHTML = 
-                    "<p style='color: red;'>Error loading weather data. Please try again.</p>";
+
+        .workspace {
+            display: grid;
+            grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+            gap: 1.75rem;
+            align-items: start;
+        }
+
+        .panel {
+            background: white;
+            border-radius: 20px;
+            padding: 1.75rem;
+            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.1);
+        }
+
+        .panel h2 {
+            margin-top: 0;
+            font-size: 1.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .panel h2 span {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #64748b;
+        }
+
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 0.35rem;
+            color: #1e293b;
+        }
+
+        select,
+        input,
+        textarea {
+            width: 100%;
+            padding: 0.75rem 0.85rem;
+            border-radius: 12px;
+            border: 1px solid #cbd5e1;
+            font-size: 1rem;
+            background: #f8fafc;
+            transition: border 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        select:focus,
+        input:focus,
+        textarea:focus {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+        }
+
+        textarea {
+            min-height: 130px;
+            resize: vertical;
+        }
+
+        button {
+            background: linear-gradient(135deg, #2563eb, #1d4ed8);
+            color: white;
+            border: none;
+            padding: 0.85rem 1.45rem;
+            border-radius: 12px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            box-shadow: 0 18px 30px rgba(37, 99, 235, 0.25);
+        }
+
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 36px rgba(37, 99, 235, 0.3);
+        }
+
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        .filters {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.85rem;
+            margin-bottom: 1rem;
+        }
+
+        .exercise-search {
+            position: sticky;
+            top: 0;
+            background: white;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid #e2e8f0;
+            margin-bottom: 1rem;
+            z-index: 1;
+        }
+
+        .exercise-search input[type="search"] {
+            padding-left: 2.5rem;
+        }
+
+        .search-wrap {
+            position: relative;
+        }
+
+        .search-wrap svg {
+            position: absolute;
+            left: 0.75rem;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 18px;
+            height: 18px;
+            stroke: #64748b;
+        }
+
+        .exercise-results {
+            max-height: 520px;
+            overflow: auto;
+            display: grid;
+            gap: 0.75rem;
+            padding-right: 0.5rem;
+        }
+
+        .exercise-card {
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            padding: 0.85rem 0.95rem;
+            background: #f8fafc;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .exercise-meta {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .exercise-meta h3 {
+            margin: 0;
+            font-size: 1rem;
+        }
+
+        .exercise-pill-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.35rem;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            background: #dbeafe;
+            color: #1d4ed8;
+            padding: 0.2rem 0.55rem;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            font-weight: 600;
+        }
+
+        .pill.secondary {
+            background: #fef3c7;
+            color: #b45309;
+        }
+
+        .pill.equipment {
+            background: #ede9fe;
+            color: #6d28d9;
+        }
+
+        .add-btn {
+            background: white;
+            color: #2563eb;
+            border: 1px solid rgba(37, 99, 235, 0.25);
+            padding: 0.65rem 1rem;
+            border-radius: 12px;
+            box-shadow: none;
+        }
+
+        .add-btn:hover {
+            transform: none;
+            box-shadow: 0 12px 20px rgba(37, 99, 235, 0.12);
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 2rem 1rem;
+            border: 1px dashed #cbd5f5;
+            border-radius: 16px;
+            background: rgba(241, 245, 249, 0.5);
+            color: #475569;
+        }
+
+        .selected-exercises {
+            display: grid;
+            gap: 1rem;
+            margin-top: 1rem;
+            max-height: 280px;
+            overflow: auto;
+            padding-right: 0.5rem;
+        }
+
+        .selected-card {
+            border: 1px solid #cbd5e1;
+            border-radius: 16px;
+            padding: 0.85rem 1rem;
+            background: white;
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .selected-card header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .selected-card h3 {
+            margin: 0;
+            font-size: 1rem;
+        }
+
+        .selected-card .controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 0.75rem;
+        }
+
+        .remove-btn {
+            background: none;
+            border: none;
+            color: #ef4444;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .plan-form {
+            display: grid;
+            gap: 1.25rem;
+        }
+
+        .inline-group {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 0.85rem;
+        }
+
+        .schedule-summary {
+            border-top: 1px solid #e2e8f0;
+            padding-top: 1rem;
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .schedule-week {
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            padding: 0.75rem 1rem;
+            background: #f8fafc;
+        }
+
+        .schedule-week h4 {
+            margin: 0 0 0.5rem;
+            font-size: 1rem;
+        }
+
+        .day-group {
+            display: grid;
+            gap: 0.35rem;
+            font-size: 0.9rem;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: #e0f2fe;
+            color: #0369a1;
+            padding: 0.25rem 0.55rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+
+        .history-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 1.5rem;
+            margin-top: 2rem;
+        }
+
+        .plan-card {
+            background: white;
+            border-radius: 18px;
+            padding: 1.25rem;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+            display: grid;
+            gap: 0.65rem;
+        }
+
+        .plan-card h3 {
+            margin: 0;
+            font-size: 1.2rem;
+            color: #1d4ed8;
+        }
+
+        .plan-card span {
+            color: #475569;
+            font-size: 0.9rem;
+        }
+
+        .plan-card footer {
+            border-top: 1px solid #e2e8f0;
+            padding-top: 0.75rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+
+        .notification-list {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .notification-card {
+            border-left: 4px solid #16a34a;
+            background: #f0fdf4;
+            border-radius: 16px;
+            padding: 1rem 1.25rem;
+            display: grid;
+            gap: 0.5rem;
+            border: 1px solid #dcfce7;
+        }
+
+        .notification-card.read {
+            opacity: 0.65;
+            background: #f8fafc;
+            border-color: #e2e8f0;
+            border-left-color: #94a3b8;
+        }
+
+        .notification-card header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .notification-card time {
+            font-size: 0.8rem;
+            color: #64748b;
+        }
+
+        .mark-read {
+            background: transparent;
+            color: #16a34a;
+            border: 1px solid rgba(22, 163, 74, 0.4);
+            padding: 0.35rem 0.8rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            box-shadow: none;
+        }
+
+        .mark-read:hover {
+            box-shadow: 0 12px 20px rgba(22, 163, 74, 0.15);
+        }
+
+        .portal-preview {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .alert {
+            border-radius: 14px;
+            padding: 0.85rem 1rem;
+            background: #fef3c7;
+            border: 1px solid #facc15;
+            color: #92400e;
+            font-size: 0.9rem;
+        }
+
+        .toast {
+            position: fixed;
+            bottom: 1.5rem;
+            right: 1.5rem;
+            background: rgba(15, 23, 42, 0.9);
+            color: white;
+            padding: 0.85rem 1.15rem;
+            border-radius: 12px;
+            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+            opacity: 0;
+            transform: translateY(16px);
+            transition: opacity 0.3s ease, transform 0.3s ease;
+            pointer-events: none;
+        }
+
+        .toast.show {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .load-more {
+            background: rgba(37, 99, 235, 0.1);
+            color: #1d4ed8;
+            border: 1px solid rgba(37, 99, 235, 0.2);
+            width: 100%;
+        }
+
+        .pill.light {
+            background: #e2e8f0;
+            color: #475569;
+        }
+
+        @media (max-width: 960px) {
+            .workspace {
+                grid-template-columns: 1fr;
+            }
+
+            header {
+                text-align: left;
             }
         }
-        
-        // 6. Run test function automatically when page loads
-        console.log("Page loaded! Try typing 'testFunction()' or 'getWeather()' in the console");
-    </script>
+    </style>
+</head>
+<body>
+<header>
+    <h1>Coach Planning Command Center</h1>
+    <p>
+        Build personalized multi-week programs at scale. Search hundreds of exercises, drop them into a weekly schedule,
+        and keep athletes updated the moment a new plan lands in their portal.
+    </p>
+</header>
+<main>
+    <div class="workspace">
+        <section class="panel" aria-labelledby="exercise-library">
+            <h2 id="exercise-library">Exercise Library <span id="library-count"></span></h2>
+            <div class="exercise-search">
+                <div class="search-wrap">
+                    <svg fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+                        <circle cx="11" cy="11" r="7" />
+                        <path d="m20 20-3.5-3.5" />
+                    </svg>
+                    <input type="search" id="exercise-search" placeholder="Search exercises, muscle groups, movements..." autocomplete="off">
+                </div>
+                <div class="filters">
+                    <div>
+                        <label for="focus-filter">Primary Focus</label>
+                        <select id="focus-filter">
+                            <option value="">All focuses</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="equipment-filter">Equipment</label>
+                        <select id="equipment-filter">
+                            <option value="">All equipment</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="exercise-results" id="exercise-results" role="listbox" aria-label="Filtered exercises"></div>
+            <button id="load-more" class="load-more" hidden>Load 40 more</button>
+        </section>
+
+        <section class="panel" aria-labelledby="plan-designer">
+            <h2 id="plan-designer">Plan Designer</h2>
+            <form class="plan-form" id="plan-form">
+                <div>
+                    <label for="athlete-select">Assign to athlete</label>
+                    <select id="athlete-select" required></select>
+                </div>
+                <div class="inline-group">
+                    <div>
+                        <label for="week-count">Number of weeks</label>
+                        <input type="number" id="week-count" min="1" max="24" value="4" required>
+                    </div>
+                    <div>
+                        <label for="start-date">Start date</label>
+                        <input type="date" id="start-date" required>
+                    </div>
+                </div>
+                <div>
+                    <label for="plan-name">Plan name</label>
+                    <input type="text" id="plan-name" placeholder="e.g., In-Season Power Block" required>
+                </div>
+                <div>
+                    <label for="plan-notes">Coaching notes</label>
+                    <textarea id="plan-notes" placeholder="Guidelines, progression cues, recovery focus..."></textarea>
+                </div>
+                <div>
+                    <h3 style="margin-bottom: 0.35rem;">Selected exercises</h3>
+                    <p style="margin: 0; font-size: 0.9rem; color: #475569;">
+                        Add exercises from the library, then assign each to a week and training day. Athletes will receive the full schedule.
+                    </p>
+                    <div class="selected-exercises" id="selected-exercises"></div>
+                    <div class="empty-state" id="empty-selected">No exercises added yet. Use the library to build the training stack.</div>
+                </div>
+                <div class="schedule-summary" id="schedule-summary"></div>
+                <div style="display: flex; justify-content: flex-end; gap: 0.75rem;">
+                    <button type="submit" id="submit-plan" disabled>Create training plan</button>
+                </div>
+            </form>
+        </section>
+    </div>
+
+    <section class="panel" style="margin-top: 2rem;" aria-labelledby="plan-history">
+        <h2 id="plan-history">Assignment history <span id="history-count"></span></h2>
+        <div class="history-grid" id="plan-history-grid"></div>
+    </section>
+
+    <section class="panel" style="margin-top: 2rem;" aria-labelledby="portal-preview">
+        <div class="portal-preview">
+            <div>
+                <h2 id="portal-preview">Athlete portal preview</h2>
+                <p style="margin: 0; font-size: 0.9rem; color: #475569;">
+                    See what an athlete experiences when plans land in their queue. New assignments surface as unread notifications until acknowledged.
+                </p>
+            </div>
+            <div class="alert" id="unread-alert" hidden>New plans waiting! Tap a notification to mark it read.</div>
+            <div class="notification-list" id="notification-list"></div>
+        </div>
+    </section>
+</main>
+<div class="toast" id="toast" role="status" aria-live="polite">Plan shared with athlete</div>
+<script>
+    const athletes = [
+        { id: "ath_001", name: "Maya Chen", goal: "Marathon debut", timezone: "EST" },
+        { id: "ath_002", name: "Jordan Lee", goal: "Hypertrophy phase", timezone: "CST" },
+        { id: "ath_003", name: "Logan Reyes", goal: "Club soccer in-season", timezone: "PST" },
+        { id: "ath_004", name: "Priya Patel", goal: "Triathlon base", timezone: "MST" },
+        { id: "ath_005", name: "Alex Murphy", goal: "Return-to-play", timezone: "EST" }
+    ];
+
+    const baseExercises = [
+        { name: "Back Squat", focus: "Lower Body Strength", equipment: "Barbell", pattern: "Squat", intensity: "Heavy" },
+        { name: "Bench Press", focus: "Upper Body Strength", equipment: "Barbell", pattern: "Press", intensity: "Moderate" },
+        { name: "Deadlift", focus: "Posterior Chain", equipment: "Barbell", pattern: "Hinge", intensity: "Heavy" },
+        { name: "Romanian Deadlift", focus: "Hamstrings", equipment: "Barbell", pattern: "Hinge", intensity: "Moderate" },
+        { name: "Pull-Up", focus: "Upper Body Pull", equipment: "Bodyweight", pattern: "Pull", intensity: "Bodyweight" },
+        { name: "Seated Row", focus: "Upper Body Pull", equipment: "Cable", pattern: "Pull", intensity: "Moderate" },
+        { name: "Split Squat", focus: "Single-Leg Strength", equipment: "Dumbbell", pattern: "Lunge", intensity: "Moderate" },
+        { name: "Hip Thrust", focus: "Glute Power", equipment: "Barbell", pattern: "Bridge", intensity: "Heavy" },
+        { name: "Box Jump", focus: "Explosive Power", equipment: "Plyo Box", pattern: "Jump", intensity: "Power" },
+        { name: "Medicine Ball Slam", focus: "Core Power", equipment: "Medicine Ball", pattern: "Slam", intensity: "Power" },
+        { name: "Plank", focus: "Core Stability", equipment: "Bodyweight", pattern: "Hold", intensity: "Stability" },
+        { name: "Hollow Rock", focus: "Core Stability", equipment: "Bodyweight", pattern: "Hold", intensity: "Stability" },
+        { name: "Farmer Carry", focus: "Grip & Core", equipment: "Kettlebell", pattern: "Carry", intensity: "Conditioning" },
+        { name: "Assault Bike", focus: "Conditioning", equipment: "Machine", pattern: "Ride", intensity: "Aerobic" },
+        { name: "Tempo Push-Up", focus: "Upper Body Strength", equipment: "Bodyweight", pattern: "Press", intensity: "Tempo" },
+        { name: "Trap Bar Deadlift", focus: "Total Strength", equipment: "Trap Bar", pattern: "Hinge", intensity: "Heavy" },
+        { name: "Overhead Press", focus: "Shoulders", equipment: "Barbell", pattern: "Press", intensity: "Moderate" },
+        { name: "Lat Pulldown", focus: "Upper Body Pull", equipment: "Cable", pattern: "Pull", intensity: "Moderate" },
+        { name: "Sled Push", focus: "Power & Drive", equipment: "Sled", pattern: "Push", intensity: "Conditioning" },
+        { name: "Nordic Curl", focus: "Hamstrings", equipment: "Assisted", pattern: "Hinge", intensity: "Eccentric" }
+    ];
+
+    const modifiers = ["(Tempo)", "(Iso Hold)", "(Speed)", "(Contrast)", "(Regression)", "(Paused)", "(Assisted)", "(Single-Arm)", "(Cluster)", "(Drop Set)", "(Eccentric)", "(Power)", "(Complex)", "(Primer)", "(Stability)"];
+
+    const exerciseLibrary = Array.from({ length: 300 }).map((_, idx) => {
+        const template = baseExercises[idx % baseExercises.length];
+        const modifier = modifiers[Math.floor(idx / baseExercises.length) % modifiers.length] || "";
+        return {
+            id: `EX-${String(idx + 1).padStart(3, "0")}`,
+            name: `${template.name} ${modifier}`.trim(),
+            focus: template.focus,
+            equipment: template.equipment,
+            pattern: template.pattern,
+            intensity: template.intensity
+        };
+    });
+
+    const focusOptions = [...new Set(exerciseLibrary.map(ex => ex.focus))].sort();
+    const equipmentOptions = [...new Set(exerciseLibrary.map(ex => ex.equipment))].sort();
+
+    const notifications = [
+        {
+            id: "notif_001",
+            athleteId: "ath_001",
+            athleteName: "Maya Chen",
+            message: "Coach shared a 6-week marathon base plan",
+            timestamp: new Date(Date.now() - 1000 * 60 * 90),
+            read: false
+        },
+        {
+            id: "notif_002",
+            athleteId: "ath_002",
+            athleteName: "Jordan Lee",
+            message: "Upper-body strength micro-cycle ready",
+            timestamp: new Date(Date.now() - 1000 * 60 * 60 * 12),
+            read: true
+        }
+    ];
+
+    const assignedPlans = [
+        {
+            id: "plan_001",
+            athleteId: "ath_003",
+            athleteName: "Logan Reyes",
+            planName: "In-season Soccer Maintenance",
+            weeks: 4,
+            startDate: "2024-05-06",
+            exerciseCount: 18,
+            focusBreakdown: ["Hamstrings", "Core Stability", "Explosive Power"],
+            createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3),
+            schedule: {
+                1: {
+                    1: ["Activation Circuit", "Back Squat (Tempo)", "Nordic Curl"],
+                    3: ["Tempo Push-Up", "Medicine Ball Slam"],
+                    5: ["Assault Bike", "Farmer Carry"]
+                }
+            }
+        }
+    ];
+
+    const DAYS_PER_WEEK = 7;
+
+    const state = {
+        filteredExercises: exerciseLibrary,
+        visibleCount: 60,
+        selected: new Map()
+    };
+
+    const focusFilter = document.getElementById("focus-filter");
+    const equipmentFilter = document.getElementById("equipment-filter");
+    const searchInput = document.getElementById("exercise-search");
+    const exerciseResults = document.getElementById("exercise-results");
+    const loadMoreBtn = document.getElementById("load-more");
+    const selectedExercisesWrap = document.getElementById("selected-exercises");
+    const emptySelected = document.getElementById("empty-selected");
+    const scheduleSummary = document.getElementById("schedule-summary");
+    const submitButton = document.getElementById("submit-plan");
+    const weekCountInput = document.getElementById("week-count");
+    const athleteSelect = document.getElementById("athlete-select");
+    const startDateInput = document.getElementById("start-date");
+    const planForm = document.getElementById("plan-form");
+    const libraryCount = document.getElementById("library-count");
+    const historyGrid = document.getElementById("plan-history-grid");
+    const historyCount = document.getElementById("history-count");
+    const notificationList = document.getElementById("notification-list");
+    const unreadAlert = document.getElementById("unread-alert");
+    const toast = document.getElementById("toast");
+
+    function populateFilters() {
+        focusOptions.forEach(option => {
+            const opt = document.createElement("option");
+            opt.value = option;
+            opt.textContent = option;
+            focusFilter.append(opt);
+        });
+
+        equipmentOptions.forEach(option => {
+            const opt = document.createElement("option");
+            opt.value = option;
+            opt.textContent = option;
+            equipmentFilter.append(opt);
+        });
+    }
+
+    function populateAthletes() {
+        athleteSelect.innerHTML = "";
+        const placeholder = new Option("Select athlete", "", true, true);
+        placeholder.disabled = true;
+        athleteSelect.append(placeholder);
+        athletes.forEach(athlete => {
+            const opt = new Option(`${athlete.name} · ${athlete.goal}`, athlete.id);
+            athleteSelect.append(opt);
+        });
+    }
+
+    function formatRelativeTime(date) {
+        const diff = Date.now() - date.getTime();
+        const minutes = Math.round(diff / 60000);
+        if (minutes < 60) return `${minutes} min ago`;
+        const hours = Math.round(minutes / 60);
+        if (hours < 24) return `${hours} hr ago`;
+        const days = Math.round(hours / 24);
+        if (days < 7) return `${days} day${days > 1 ? "s" : ""} ago`;
+        return date.toLocaleDateString();
+    }
+
+    function filterExercises() {
+        const focus = focusFilter.value;
+        const equipment = equipmentFilter.value;
+        const query = searchInput.value.trim().toLowerCase();
+        state.filteredExercises = exerciseLibrary.filter(exercise => {
+            const matchesFocus = focus ? exercise.focus === focus : true;
+            const matchesEquipment = equipment ? exercise.equipment === equipment : true;
+            const matchesQuery = query ?
+                `${exercise.name} ${exercise.focus} ${exercise.pattern} ${exercise.equipment}`.toLowerCase().includes(query) :
+                true;
+            return matchesFocus && matchesEquipment && matchesQuery;
+        });
+        state.visibleCount = 60;
+        renderExerciseList();
+    }
+
+    function renderExerciseList() {
+        exerciseResults.innerHTML = "";
+        const visibleExercises = state.filteredExercises.slice(0, state.visibleCount);
+        libraryCount.textContent = `${state.filteredExercises.length} results`;
+
+        if (!visibleExercises.length) {
+            const empty = document.createElement("div");
+            empty.className = "empty-state";
+            empty.textContent = "No exercises match the filters. Adjust search or clear filters.";
+            exerciseResults.append(empty);
+            loadMoreBtn.hidden = true;
+            return;
+        }
+
+        visibleExercises.forEach(exercise => {
+            const card = document.createElement("div");
+            card.className = "exercise-card";
+            card.role = "option";
+            card.setAttribute("data-id", exercise.id);
+
+            const meta = document.createElement("div");
+            meta.className = "exercise-meta";
+            const title = document.createElement("h3");
+            title.textContent = `${exercise.name}`;
+            meta.append(title);
+
+            const pillGroup = document.createElement("div");
+            pillGroup.className = "exercise-pill-group";
+            pillGroup.innerHTML = `
+                <span class="pill">${exercise.focus}</span>
+                <span class="pill secondary">${exercise.pattern}</span>
+                <span class="pill equipment">${exercise.equipment}</span>
+                <span class="pill light">${exercise.intensity}</span>
+            `;
+            meta.append(pillGroup);
+
+            card.append(meta);
+
+            const addBtn = document.createElement("button");
+            addBtn.type = "button";
+            addBtn.className = "add-btn";
+            addBtn.textContent = state.selected.has(exercise.id) ? "Added" : "Add";
+            addBtn.disabled = state.selected.has(exercise.id);
+            addBtn.addEventListener("click", () => addExerciseToSelection(exercise));
+            card.append(addBtn);
+
+            exerciseResults.append(card);
+        });
+
+        loadMoreBtn.hidden = state.visibleCount >= state.filteredExercises.length;
+    }
+
+    function renderSelectedExercises() {
+        selectedExercisesWrap.innerHTML = "";
+        const exercises = Array.from(state.selected.values());
+        if (!exercises.length) {
+            emptySelected.hidden = false;
+            submitButton.disabled = true;
+            scheduleSummary.innerHTML = "";
+            return;
+        }
+
+        emptySelected.hidden = true;
+        submitButton.disabled = false;
+
+        exercises.sort((a, b) => {
+            if (a.week !== b.week) return a.week - b.week;
+            if (a.day !== b.day) return a.day - b.day;
+            return a.name.localeCompare(b.name);
+        });
+
+        exercises.forEach(exercise => {
+            const card = document.createElement("article");
+            card.className = "selected-card";
+            card.setAttribute("data-id", exercise.id);
+
+            const header = document.createElement("header");
+            const title = document.createElement("h3");
+            title.textContent = exercise.name;
+            header.append(title);
+
+            const remove = document.createElement("button");
+            remove.type = "button";
+            remove.className = "remove-btn";
+            remove.textContent = "Remove";
+            remove.addEventListener("click", () => removeExercise(exercise.id));
+            header.append(remove);
+            card.append(header);
+
+            const pillGroup = document.createElement("div");
+            pillGroup.className = "exercise-pill-group";
+            pillGroup.innerHTML = `
+                <span class="pill">${exercise.focus}</span>
+                <span class="pill secondary">${exercise.pattern}</span>
+                <span class="pill equipment">${exercise.equipment}</span>
+                <span class="pill light">${exercise.intensity}</span>
+            `;
+            card.append(pillGroup);
+
+            const controls = document.createElement("div");
+            controls.className = "controls";
+
+            const weekWrap = document.createElement("label");
+            weekWrap.textContent = "Week";
+            const weekSelect = document.createElement("select");
+            weekSelect.innerHTML = createWeekOptions();
+            exercise.week = Math.min(exercise.week, Number(weekCountInput.value));
+            weekSelect.value = String(exercise.week);
+            weekSelect.addEventListener("change", (event) => {
+                exercise.week = Number(event.target.value);
+                renderScheduleSummary();
+            });
+            weekWrap.append(weekSelect);
+
+            const dayWrap = document.createElement("label");
+            dayWrap.textContent = "Day";
+            const daySelect = document.createElement("select");
+            daySelect.innerHTML = createDayOptions();
+            daySelect.value = String(exercise.day);
+            daySelect.addEventListener("change", (event) => {
+                exercise.day = Number(event.target.value);
+                renderScheduleSummary();
+            });
+            dayWrap.append(daySelect);
+
+            controls.append(weekWrap, dayWrap);
+            card.append(controls);
+
+            selectedExercisesWrap.append(card);
+        });
+
+        renderScheduleSummary();
+    }
+
+    function createWeekOptions() {
+        const weeks = Number(weekCountInput.value) || 1;
+        return Array.from({ length: weeks }, (_, i) => `<option value="${i + 1}">Week ${i + 1}</option>`).join("");
+    }
+
+    function createDayOptions() {
+        return Array.from({ length: DAYS_PER_WEEK }, (_, i) => `<option value="${i + 1}">Day ${i + 1}</option>`).join("");
+    }
+
+    function addExerciseToSelection(exercise) {
+        if (state.selected.has(exercise.id)) return;
+        const week = Math.min(state.selected.size + 1, Number(weekCountInput.value)) || 1;
+        state.selected.set(exercise.id, {
+            ...exercise,
+            week,
+            day: ((state.selected.size) % DAYS_PER_WEEK) + 1
+        });
+        renderExerciseList();
+        renderSelectedExercises();
+    }
+
+    function removeExercise(id) {
+        state.selected.delete(id);
+        renderExerciseList();
+        renderSelectedExercises();
+    }
+
+    function renderScheduleSummary() {
+        scheduleSummary.innerHTML = "";
+        const exercises = Array.from(state.selected.values());
+        if (!exercises.length) return;
+
+        const weeks = Number(weekCountInput.value) || 1;
+        for (let w = 1; w <= weeks; w++) {
+            const weekExercises = exercises.filter(ex => ex.week === w);
+            if (!weekExercises.length) continue;
+
+            const weekCard = document.createElement("div");
+            weekCard.className = "schedule-week";
+            const title = document.createElement("h4");
+            title.textContent = `Week ${w}`;
+            weekCard.append(title);
+
+            const days = {};
+            weekExercises.forEach(ex => {
+                if (!days[ex.day]) days[ex.day] = [];
+                days[ex.day].push(ex);
+            });
+
+            const dayGroup = document.createElement("div");
+            dayGroup.className = "day-group";
+
+            Object.keys(days).sort((a, b) => a - b).forEach(day => {
+                const dayLine = document.createElement("div");
+                const exercisesList = days[day].map(ex => ex.name).join(", ");
+                dayLine.innerHTML = `<strong>Day ${day}:</strong> ${exercisesList}`;
+                dayGroup.append(dayLine);
+            });
+
+            weekCard.append(dayGroup);
+            scheduleSummary.append(weekCard);
+        }
+    }
+
+    function renderPlanHistory() {
+        historyGrid.innerHTML = "";
+        if (!assignedPlans.length) {
+            const empty = document.createElement("div");
+            empty.className = "empty-state";
+            empty.textContent = "No plans assigned yet. Share your first training block to populate the history.";
+            historyGrid.append(empty);
+        } else {
+            assignedPlans
+                .slice()
+                .sort((a, b) => b.createdAt - a.createdAt)
+                .forEach(plan => {
+                    const card = document.createElement("article");
+                    card.className = "plan-card";
+                    card.innerHTML = `
+                        <h3>${plan.planName}</h3>
+                        <span>${plan.athleteName} · ${plan.weeks} week${plan.weeks > 1 ? "s" : ""} · ${plan.exerciseCount} exercise${plan.exerciseCount !== 1 ? "s" : ""}</span>
+                        <span>Kick-off: ${new Date(plan.startDate).toLocaleDateString()}</span>
+                        <div class="tag">${plan.focusBreakdown.slice(0, 3).join(" · ")}</div>
+                        <footer>${formatRelativeTime(plan.createdAt)} · Assigned</footer>
+                    `;
+                    historyGrid.append(card);
+                });
+        }
+        historyCount.textContent = `${assignedPlans.length} plan${assignedPlans.length !== 1 ? "s" : ""}`;
+    }
+
+    function renderNotifications() {
+        notificationList.innerHTML = "";
+        const unread = notifications.some(n => !n.read);
+        unreadAlert.hidden = !unread;
+
+        if (!notifications.length) {
+            const empty = document.createElement("div");
+            empty.className = "empty-state";
+            empty.textContent = "No notifications yet. Athletes will see plan drops here.";
+            notificationList.append(empty);
+            return;
+        }
+
+        notifications
+            .slice()
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .forEach(notification => {
+                const card = document.createElement("article");
+                card.className = `notification-card ${notification.read ? "read" : ""}`;
+
+                const header = document.createElement("header");
+                const title = document.createElement("strong");
+                title.textContent = notification.athleteName;
+                header.append(title);
+
+                if (!notification.read) {
+                    const markBtn = document.createElement("button");
+                    markBtn.type = "button";
+                    markBtn.className = "mark-read";
+                    markBtn.textContent = "Mark as read";
+                    markBtn.addEventListener("click", () => {
+                        notification.read = true;
+                        renderNotifications();
+                    });
+                    header.append(markBtn);
+                }
+
+                card.append(header);
+
+                const message = document.createElement("p");
+                message.style.margin = "0";
+                message.textContent = notification.message;
+                card.append(message);
+
+                const timestamp = document.createElement("time");
+                timestamp.dateTime = notification.timestamp.toISOString();
+                timestamp.textContent = formatRelativeTime(notification.timestamp);
+                card.append(timestamp);
+
+                notificationList.append(card);
+            });
+    }
+
+    function showToast(message) {
+        toast.textContent = message;
+        toast.classList.add("show");
+        setTimeout(() => toast.classList.remove("show"), 3200);
+    }
+
+    function resetForm() {
+        planForm.reset();
+        weekCountInput.value = 4;
+        startDateInput.valueAsDate = new Date();
+        state.selected.clear();
+        filterExercises();
+        renderSelectedExercises();
+    }
+
+    function handlePlanSubmit(event) {
+        event.preventDefault();
+        const athleteId = athleteSelect.value;
+        const weeks = Number(weekCountInput.value);
+        const startDate = startDateInput.value;
+        const planName = document.getElementById("plan-name").value.trim();
+        const notes = document.getElementById("plan-notes").value.trim();
+        const selectedExercises = Array.from(state.selected.values());
+
+        if (!athleteId || !weeks || !startDate || !planName || !selectedExercises.length) {
+            showToast("Please complete the form and add exercises.");
+            return;
+        }
+
+        const athlete = athletes.find(a => a.id === athleteId);
+        const schedule = {};
+        const focusBreakdown = new Set();
+
+        selectedExercises.forEach(ex => {
+            if (!schedule[ex.week]) schedule[ex.week] = {};
+            if (!schedule[ex.week][ex.day]) schedule[ex.week][ex.day] = [];
+            schedule[ex.week][ex.day].push(ex.name);
+            focusBreakdown.add(ex.focus);
+        });
+
+        const newPlan = {
+            id: `plan_${Date.now()}`,
+            athleteId,
+            athleteName: athlete.name,
+            planName,
+            weeks,
+            startDate,
+            notes,
+            exerciseCount: selectedExercises.length,
+            focusBreakdown: Array.from(focusBreakdown),
+            createdAt: new Date(),
+            schedule
+        };
+
+        assignedPlans.push(newPlan);
+
+        notifications.push({
+            id: `notif_${Date.now()}`,
+            athleteId,
+            athleteName: athlete.name,
+            message: `${planName} (${selectedExercises.length} exercises) assigned to you`,
+            timestamp: new Date(),
+            read: false
+        });
+
+        renderPlanHistory();
+        renderNotifications();
+        showToast(`${planName} shared with ${athlete.name}`);
+        resetForm();
+    }
+
+    function init() {
+        populateFilters();
+        populateAthletes();
+        filterExercises();
+        renderPlanHistory();
+        renderNotifications();
+        renderSelectedExercises();
+        startDateInput.valueAsDate = new Date();
+    }
+
+    searchInput.addEventListener("input", filterExercises);
+    focusFilter.addEventListener("change", filterExercises);
+    equipmentFilter.addEventListener("change", filterExercises);
+    loadMoreBtn.addEventListener("click", () => {
+        state.visibleCount += 40;
+        renderExerciseList();
+    });
+
+    weekCountInput.addEventListener("change", () => {
+        if (Number(weekCountInput.value) < 1) weekCountInput.value = 1;
+        renderSelectedExercises();
+    });
+
+    planForm.addEventListener("submit", handlePlanSubmit);
+
+    init();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the dashboard with an exercise library that supports searching, filtering, and paging through hundreds of movements
- add a selectable exercise cart with week/day assignments that feeds a generated weekly schedule summary
- refresh plan submission, history, and athlete notifications to reflect the richer plan metadata

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4bc98b7ec832282cc5c4534f26e5a